### PR TITLE
Fix dependency list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
   "sentencepiece",
   "tensorboardX",
   "tqdm",
+  "absl-py",
+  "optax",
+  "orbax-checkpoint",
+  "qwix @ git+https://github.com/google/qwix",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- add missing dependencies to `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'absl')*

------
https://chatgpt.com/codex/tasks/task_e_684da3d9ae84832493133ada0ba6534b